### PR TITLE
Require OCaml >= 4.02.0

### DIFF
--- a/opam
+++ b/opam
@@ -41,4 +41,4 @@ build-test: [
   ["ocaml" "setup.ml" "-test"]
 ]
 
-available: [ocaml-version >= "4.01.0"]
+available: [ocaml-version >= "4.02.0"]


### PR DESCRIPTION
Error was:

    File "unix/lofs9p.ml", line 75, characters 4-5:
    Parse error: [match_case0] expected (in [match_case])