### PR TITLE
Improving lofs9p

### DIFF
--- a/lib/buffered9PReader.ml
+++ b/lib/buffered9PReader.ml
@@ -14,8 +14,10 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
  *)
+
 open Result
 open Error
+open Infix
 
 module Make(Log: S.LOG)(FLOW: V1_LWT.FLOW) = struct
   open Log
@@ -38,13 +40,6 @@ module Make(Log: S.LOG)(FLOW: V1_LWT.FLOW) = struct
     | `Ok x -> f x
     | `Eof -> return (error_msg "Caught EOF on underlying FLOW")
     | `Error e -> return (error_msg "Unexpected error on underlying FLOW: %s" (FLOW.error_message e))
-
-  (* For Result + Lwt *)
-  let (>>*=) m f =
-   let open Lwt in
-   m >>= function
-   | Ok x -> f x
-   | Error x -> Lwt.return (Error x)
 
   let read_exactly t n =
     let output = Cstruct.create n in

--- a/lib/client.ml
+++ b/lib/client.ml
@@ -14,8 +14,10 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
  *)
+
 open Result
 open Error
+open Infix
 
 module Make(Log: S.LOG)(FLOW: V1_LWT.FLOW) = struct
   module Reader = Buffered9PReader.Make(Log)(FLOW)
@@ -49,13 +51,6 @@ module Make(Log: S.LOG)(FLOW: V1_LWT.FLOW) = struct
     | `Ok x -> f x
     | `Eof -> return (error_msg "Caught EOF on underlying FLOW")
     | `Error e -> return (error_msg "Unexpected error on underlying FLOW: %s" (FLOW.error_message e))
-
-  (* For Result + Lwt *)
-  let (>>*=) m f =
-   let open Lwt in
-   m >>= function
-   | Ok x -> f x
-   | Error x -> Lwt.return (Error x)
 
   let read_one_packet reader =
     Reader.read reader

--- a/lib/filesystem.mli
+++ b/lib/filesystem.mli
@@ -27,4 +27,10 @@ module type S = sig
   val read: Server.info -> Request.Read.t -> Response.payload Error.t Lwt.t
 
   val stat: Server.info -> Request.Stat.t -> Response.payload Error.t Lwt.t
+
+  val create: Server.info -> Request.Create.t -> Response.payload Error.t Lwt.t
+
+  val write: Server.info -> Request.Write.t -> Response.payload Error.t Lwt.t
+
+  val remove: Server.info -> Request.Remove.t -> Response.payload Error.t Lwt.t
 end

--- a/lib/filesystem.mli
+++ b/lib/filesystem.mli
@@ -33,4 +33,6 @@ module type S = sig
   val write: Server.info -> Request.Write.t -> Response.payload Error.t Lwt.t
 
   val remove: Server.info -> Request.Remove.t -> Response.payload Error.t Lwt.t
+
+  val wstat: Server.info -> Request.Wstat.t -> Response.payload Error.t Lwt.t
 end

--- a/lib/handler.ml
+++ b/lib/handler.ml
@@ -25,9 +25,10 @@ module Make(Filesystem : Filesystem.S) = struct
     | Read read -> Filesystem.read info read
     | Clunk clunk -> Filesystem.clunk info clunk
     | Stat stat -> Filesystem.stat info stat
-    | Create _
-    | Write _
-    | Version _ | Auth _ | Flush _ | Attach _ | Remove _ | Wstat _ ->
+    | Create create -> Filesystem.create info create
+    | Write write -> Filesystem.write info write
+    | Remove remove -> Filesystem.remove info remove
+    | Version _ | Auth _ | Flush _ | Attach _ | Wstat _ ->
       Lwt.return (Result.Ok (Response.Err {
         Response.Err.ename = "not implemented";
         errno = None;

--- a/lib/handler.ml
+++ b/lib/handler.ml
@@ -28,7 +28,8 @@ module Make(Filesystem : Filesystem.S) = struct
     | Create create -> Filesystem.create info create
     | Write write -> Filesystem.write info write
     | Remove remove -> Filesystem.remove info remove
-    | Version _ | Auth _ | Flush _ | Attach _ | Wstat _ ->
+    | Wstat wstat -> Filesystem.wstat info wstat
+    | Version _ | Auth _ | Flush _ | Attach _ ->
       Lwt.return (Result.Ok (Response.Err {
         Response.Err.ename = "not implemented";
         errno = None;

--- a/lib/request.ml
+++ b/lib/request.ml
@@ -349,16 +349,20 @@ module Wstat = struct
     stat: Types.Stat.t;
   } with sexp
 
-  let sizeof t = (Fid.sizeof t.fid) + (Types.Stat.sizeof t.stat)
+  let sizeof t = (Fid.sizeof t.fid) + 2 + (Types.Stat.sizeof t.stat)
 
   let write t rest =
     Fid.write t.fid rest
+    >>= fun rest ->
+    Int16.write (Types.Stat.sizeof t.stat) rest
     >>= fun rest ->
     Types.Stat.write t.stat rest
 
   let read rest =
     Fid.read rest
     >>= fun (fid, rest) ->
+    Int16.read rest
+    >>= fun (_len, rest) ->
     Types.Stat.read rest
     >>= fun (stat, rest) ->
     return ( { fid; stat }, rest )

--- a/lib/request.ml
+++ b/lib/request.ml
@@ -470,7 +470,7 @@ let read rest =
     | 122 -> Remove.read rest  >>= fun (x, rest) -> return ((Remove x), rest)
     | 124 -> Stat.read rest    >>= fun (x, rest) -> return ((Stat x), rest)
     | 126 -> Wstat.read rest   >>= fun (x, rest) -> return ((Wstat x), rest)
-    | ty  -> error_msg "unknown packet type %d\n%!" ty
+    | ty  -> error_msg "unknown packet type %d" ty
   ) >>= fun (payload, rest) ->
   return ( { tag; payload }, rest )
 

--- a/lib/request.mli
+++ b/lib/request.mli
@@ -182,4 +182,8 @@ type t = {
 
 include S.SERIALISABLE with type t := t
 
+val read_header:
+  Cstruct.t -> (Int32.t * Types.Int8.t * Types.Tag.t * Cstruct.t,
+                [ `Msg of string]) result
+
 val to_string: t -> string

--- a/lib/server.ml
+++ b/lib/server.ml
@@ -14,8 +14,10 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
  *)
+
 open Error
 open Result
+open Infix
 
 type info = {
   root: Types.Fid.t;
@@ -46,13 +48,6 @@ module Make(Log: S.LOG)(FLOW: V1_LWT.FLOW) = struct
     | `Ok x -> f x
     | `Eof -> return (error_msg "Caught EOF on underlying FLOW")
     | `Error e -> return (error_msg "Unexpected error on underlying FLOW: %s" (FLOW.error_message e))
-
-  (* For Result + Lwt *)
-  let (>>*=) m f =
-   let open Lwt in
-   m >>= function
-   | Ok x -> f x
-   | Error x -> Lwt.return (Error x)
 
   let write_one_packet writer response =
     debug "S %s" (Response.to_string response);

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -74,7 +74,7 @@ module Int32 = struct
 
   let sizeof _ = 4
 
-  let any = Int32.(neg one)
+  let any = 0xFFFFFFFF_l
 
   let is_any x = x = any
 
@@ -95,7 +95,7 @@ module Int64 = struct
 
   let sizeof _ = 8
 
-  let any = Int64.(neg one)
+  let any = 0xFFFFFFFFFFFFFFFF_L
 
   let is_any x = x = any
 

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -492,7 +492,7 @@ module Stat = struct
 
   let read buf =
     Int16.read buf
-    >>= fun (_len, rest) ->
+    >>= fun (sz, rest) ->
     Int16.read rest
     >>= fun (ty, rest) ->
     Int32.read rest
@@ -521,9 +521,9 @@ module Stat = struct
     let muid = Data.to_string muid in
     let t = { ty; dev; qid; mode; atime; mtime; length; name; uid; gid; muid; u = None } in
     (* We are often decoding contiguous arrays of Stat structures,
-       so we must use the _len field to discover where the data ends. *)
+       so we must use the sz field to discover where the data ends. *)
     let consumed = Cstruct.len buf - (Cstruct.len rest) in
-    if consumed = _len + 2 (* Size of the _len field itself *)
+    if consumed = sz + 2 (* Size of the sz field itself *)
     then return (t, rest)
     else
       Data.read rest
@@ -538,7 +538,7 @@ module Stat = struct
       let u = Some { extension; n_uid; n_gid; n_muid } in
       (* In case of future extensions, remove trailing garbage *)
       let consumed = Cstruct.len buf - (Cstruct.len rest) in
-      let trailing_garbage = consumed - _len - 2 in
+      let trailing_garbage = consumed - sz - 2 in
       let rest = Cstruct.shift rest trailing_garbage in
       return ({ t with u }, rest)
 

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -28,6 +28,10 @@ module Int8 = struct
 
   let sizeof _ = 1
 
+  let any = 0xFF
+
+  let is_any x = x = any
+
   let read buf =
     big_enough_for "Int8.read" buf 1
     >>= fun () ->
@@ -44,6 +48,10 @@ module Int16 = struct
   type t = int with sexp
 
   let sizeof _ = 2
+
+  let any = 0xFFFF
+
+  let is_any x = x = any
 
   let read buf =
     big_enough_for "Int16.read" buf 2
@@ -66,6 +74,10 @@ module Int32 = struct
 
   let sizeof _ = 4
 
+  let any = Int32.(neg one)
+
+  let is_any x = x = any
+
   let read buf =
     big_enough_for "Int32.read" buf 4
     >>= fun () ->
@@ -82,6 +94,10 @@ module Int64 = struct
   type t = int64 with sexp
 
   let sizeof _ = 8
+
+  let any = Int64.(neg one)
+
+  let is_any x = x = any
 
   let read buf =
     big_enough_for "Int64.read" buf 8
@@ -170,6 +186,7 @@ module FileMode = struct
     is_socket: bool;
     is_setuid: bool;
     is_setgid: bool;
+    is_any: bool;
   } with sexp
 
   let make ?(owner=[]) ?(group=[]) ?(other=[]) ?(is_directory=false)
@@ -178,7 +195,15 @@ module FileMode = struct
     ?(is_setuid=false) ?(is_setgid=false) () = {
     owner; group; other; is_directory; append_only; exclusive; is_mount;
     is_auth; temporary; is_device; is_symlink; is_namedpipe; is_socket;
-    is_setuid; is_setgid;
+    is_setuid; is_setgid; is_any = false;
+  }
+
+  let any = {
+    owner = []; group = []; other = [];
+    is_directory = false; append_only = false; exclusive = false;
+    is_mount = false; is_auth = false; temporary = false; is_device = false;
+    is_symlink = false; is_namedpipe = false; is_socket = false;
+    is_setuid = false; is_setgid = false; is_any = true;
   }
 
   let sizeof _ = 4
@@ -199,54 +224,71 @@ module FileMode = struct
       | `Execute -> bit 0 in
     List.fold_left Int32.logor 0l (List.map to_nibble permissions)
 
+  let is_any { is_any } = is_any
+
   let read rest =
     Int32.read rest
     >>= fun (x, rest) ->
-    let is_directory = is_set x 31 in
-    let append_only  = is_set x 30 in
-    let exclusive    = is_set x 29 in
-    let is_mount     = is_set x 28 in
-    let is_auth      = is_set x 27 in
-    let temporary    = is_set x 26 in
-    let is_symlink   = is_set x 25 in
-    let is_device    = is_set x 23 in
-    let is_namedpipe = is_set x 21 in
-    let is_socket    = is_set x 20 in
-    let is_setuid    = is_set x 19 in
-    let is_setgid    = is_set x 18 in
-    let owner = permissions_of_nibble (Int32.shift_right x 6) in
-    let group = permissions_of_nibble (Int32.shift_right x 3) in
-    let other = permissions_of_nibble (Int32.shift_right x 0) in
-    let t = {
-      owner; group; other; is_directory; append_only; exclusive; is_mount;
-      is_auth; temporary; is_device; is_symlink; is_namedpipe; is_socket;
-      is_setuid; is_setgid } in
-    return (t, rest)
+    if Int32.is_any x
+    then return (any, rest)
+    else
+      let is_directory = is_set x 31 in
+      let append_only  = is_set x 30 in
+      let exclusive    = is_set x 29 in
+      let is_mount     = is_set x 28 in
+      let is_auth      = is_set x 27 in
+      let temporary    = is_set x 26 in
+      let is_symlink   = is_set x 25 in
+      let is_device    = is_set x 23 in
+      let is_namedpipe = is_set x 21 in
+      let is_socket    = is_set x 20 in
+      let is_setuid    = is_set x 19 in
+      let is_setgid    = is_set x 18 in
+      let owner = permissions_of_nibble (Int32.shift_right x 6) in
+      let group = permissions_of_nibble (Int32.shift_right x 3) in
+      let other = permissions_of_nibble (Int32.shift_right x 0) in
+      let t = {
+        owner; group; other; is_directory; append_only; exclusive; is_mount;
+        is_auth; temporary; is_device; is_symlink; is_namedpipe; is_socket;
+        is_setuid; is_setgid; is_any = false } in
+      return (t, rest)
 
   let write t rest =
-    let x = List.fold_left Int32.logor 0l [
-      if t.is_directory then bit 31 else 0l;
-      if t.append_only  then bit 30 else 0l;
-      if t.exclusive    then bit 29 else 0l;
-      if t.is_mount     then bit 28 else 0l;
-      if t.is_auth      then bit 27 else 0l;
-      if t.temporary    then bit 26 else 0l;
-      if t.is_symlink   then bit 25 else 0l;
-      if t.is_device    then bit 23 else 0l;
-      if t.is_namedpipe then bit 21 else 0l;
-      if t.is_socket    then bit 20 else 0l;
-      if t.is_setuid    then bit 19 else 0l;
-      if t.is_setgid    then bit 18 else 0l;
-      Int32.shift_left (nibble_of_permissions t.owner) 6;
-      Int32.shift_left (nibble_of_permissions t.group) 3;
-      Int32.shift_left (nibble_of_permissions t.other) 0;
-    ] in
-    Int32.write x rest
+    if t.is_any
+    then Int32.(write any rest)
+    else
+      let x = List.fold_left Int32.logor 0l [
+        if t.is_directory then bit 31 else 0l;
+        if t.append_only  then bit 30 else 0l;
+        if t.exclusive    then bit 29 else 0l;
+        if t.is_mount     then bit 28 else 0l;
+        if t.is_auth      then bit 27 else 0l;
+        if t.temporary    then bit 26 else 0l;
+        if t.is_symlink   then bit 25 else 0l;
+        if t.is_device    then bit 23 else 0l;
+        if t.is_namedpipe then bit 21 else 0l;
+        if t.is_socket    then bit 20 else 0l;
+        if t.is_setuid    then bit 19 else 0l;
+        if t.is_setgid    then bit 18 else 0l;
+        Int32.shift_left (nibble_of_permissions t.owner) 6;
+        Int32.shift_left (nibble_of_permissions t.group) 3;
+        Int32.shift_left (nibble_of_permissions t.other) 0;
+      ] in
+      Int32.write x rest
 end
 
 
 module Qid = struct
-  type flag = Directory | AppendOnly | Exclusive | Mount | Auth | Temporary | Link with sexp
+  type flag =
+    | Directory
+    | AppendOnly
+    | Exclusive
+    | Mount
+    | Auth
+    | Temporary
+    | Symlink
+    | Link
+  with sexp
 
   type t = {
    flags: flag list;
@@ -276,7 +318,8 @@ module Qid = struct
     Mount,      0x10;
     Auth,       0x08;
     Temporary,  0x04;
-    Link,       0x02;
+    Symlink,    0x02;
+    Link,       0x01;
   ]
   let flags' = List.map (fun (x, y) -> y, x) flags
 
@@ -289,6 +332,11 @@ module Qid = struct
   let needed = 13
 
   let sizeof _ = needed
+
+  let is_any_flags flags = Int8.is_any (to_int flags)
+
+  let is_any { flags; version; id } =
+    Int32.is_any version && Int64.is_any id && is_any_flags flags
 
   let write t rest =
     big_enough_for "Qid.write" rest needed

--- a/lib/types.mli
+++ b/lib/types.mli
@@ -33,6 +33,8 @@ end
 module Int16 : sig
   type t = int with sexp
 
+  val is_any: t -> bool
+
   include S.SERIALISABLE with type t := t
 end
 
@@ -42,11 +44,15 @@ module Int32 : sig
   val t_of_sexp: Sexp.t -> t
   val sexp_of_t: t -> Sexp.t
 
+  val is_any: t -> bool
+
   include S.SERIALISABLE with type t := t
 end
 
 module Int64 : sig
   type t = int64 with sexp
+
+  val is_any: t -> bool
 
   include S.SERIALISABLE with type t := t
 end
@@ -114,6 +120,7 @@ module FileMode : sig
     is_socket: bool;        (** 9P2000.u: true if file is a socket *)
     is_setuid: bool;        (** 9P2000.u: true if file is setuid *)
     is_setgid: bool;        (** 9P2000.u: true if file is setgid *)
+    is_any: bool;           (** true if the mode is a wstat 'any' value *)
   } with sexp
   (** A 'mode' returned from a call to "Stat" *)
 
@@ -121,6 +128,8 @@ module FileMode : sig
     ?is_directory:bool -> ?append_only:bool -> ?exclusive:bool -> ?is_mount:bool -> ?is_auth:bool -> ?temporary:bool ->
     ?is_device:bool -> ?is_symlink:bool -> ?is_namedpipe:bool -> ?is_socket:bool -> ?is_setuid:bool ->
     ?is_setgid:bool -> unit -> t
+
+  val is_any: t -> bool
 
   include S.SERIALISABLE with type t := t
 end
@@ -133,7 +142,8 @@ module Qid : sig
     | Mount      (** file is a mountpoint *)
     | Auth       (** file is an authentication file *)
     | Temporary  (** file is temporary and won't be backed up *)
-    | Link       (** 9P2000.u: file is a symlink *)
+    | Symlink    (** 9P2000.u: file is a symlink *)
+    | Link       (** 9P2000.u: file is a hard-link *)
 
   with sexp
 
@@ -144,6 +154,8 @@ module Qid : sig
   } with sexp
   (** The server's unique id for the file. Two files are the same
       if and only if the Qids are the same. *)
+
+  val is_any: t -> bool
 
   val file: ?id:int64 -> ?version:int32 -> ?append_only:bool -> ?exclusive:bool ->
     ?mount:bool -> ?auth:bool -> ?temporary:bool -> ?link:bool -> unit -> t

--- a/unix/lofs9p.ml
+++ b/unix/lofs9p.ml
@@ -239,7 +239,8 @@ module New(Params : sig val root : string list end) = struct
 
   let set_mode path mode = Lwt.return ()
   let set_times path atime mtime = Lwt.return ()
-  let set_length path length = Lwt.return ()
+  let set_length path length =
+    Lwt_unix.LargeFile.truncate path length
   let rename_local path newpath = Lwt.return ()
   let set_owner path owner = Lwt.return ()
   let set_group path group = Lwt.return ()


### PR DESCRIPTION
Stat names are fixed, stat struct is fixed, walking is fixed, more infix factoring, error handling is more graceful (but server is more verbose), wstat request parsing bug fixed, added create, added remove, fixed some style issues previously introduced, added wstat 'any' concept, implemented wstat length and wstat name. Review welcome.